### PR TITLE
Support for MU Domain Mapping

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -44,6 +44,7 @@ define('WP_SITEURL', env('WP_SITEURL'));
 define('CONTENT_DIR', '/app');
 define('WP_CONTENT_DIR', $webroot_dir . CONTENT_DIR);
 define('WP_CONTENT_URL', WP_HOME . CONTENT_DIR);
+define('PLUGINDIR', 'app/plugins');
 
 /**
  * DB settings


### PR DESCRIPTION
see https://wordpress.org/support/topic/plugin-wordpress-mu-domain-mapping-problems-with-custom-wp-content-directory

When MU domain mapping is enabled, custom plugins directory locations need additional PLUGINDIR setting to function correctly.
